### PR TITLE
Scrolling V1

### DIFF
--- a/components/ui/pane.tsx
+++ b/components/ui/pane.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, ReactNode } from "react";
+import { useInView } from "react-intersection-observer";
 
 interface PaneProps {
   className?: string;
@@ -6,10 +7,10 @@ interface PaneProps {
   isActive: boolean;
   index: number;
   children: ReactNode;
+  onScrollToBottom: () => void;
 }
 
 function getStyle(isTransformed: boolean, index: number) {
-
   const percent = `${index * 5}%`;
   if (isTransformed) {
     return { right: percent, transform: "translate(-75vw)" };
@@ -24,9 +25,14 @@ export function Pane({
   isTransformed,
   children,
   className,
+  onScrollToBottom,
   ...props
 }: PaneProps) {
   const paneRef = useRef<HTMLDivElement>(null);
+
+  const { ref: bottomRef, inView } = useInView({
+    threshold: 0,
+  });
 
   // Scroll to top when the pane becomes active
   useEffect(() => {
@@ -36,25 +42,30 @@ export function Pane({
   }, [isActive]);
 
   // Reset scroll position when the pane becomes inactive
+  // useEffect(() => {
+  //   if (!isActive && paneRef.current) {
+  //     paneRef.current.scrollTo(0, 0);
+  //   }
+  // }, [isActive]);
+
   useEffect(() => {
-    if (!isActive && paneRef.current) {
-      paneRef.current.scrollTo(0, 0);
+    if (inView && onScrollToBottom) {
+      onScrollToBottom();
     }
-  }, [isActive]);
+  }, [inView]);
 
   return (
     <div
       ref={paneRef}
       style={getStyle(isTransformed, index)}
       className={`transition duration-700 ease-[cubic-bezier(0.42, 0, 0.58, 1)] justify-items-end ${
-        isActive
-          ? " h-screen overflow-auto"
-          : "overflow-hidden h-screen"
-      }  ${className ?? ""} justify-items-end flex flex-row min-w-96 md:min-w-0 p-6`}
+        isActive ? " h-screen overflow-auto" : "overflow-hidden h-screen"
+      }  ${className ?? ""} min-w-96 md:min-w-0 p-6`}
       {...props}
     >
-      
-      {children}
+      <div className="flex flex-row">{children}</div>
+      <div className="h-[150px]" />
+      <div ref={bottomRef} className="h-[10px]" />
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.54.1",
+        "react-intersection-observer": "^9.15.1",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
         "sonner": "^1.7.1",
@@ -63,6 +64,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "postcss": "^8.5.1",
+        "prettier": "^3.4.2",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"
       }
@@ -2998,6 +3000,21 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -3068,6 +3085,20 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.15.1.tgz",
+      "integrity": "sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.54.1",
+    "react-intersection-observer": "^9.15.1",
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
     "sonner": "^1.7.1",
@@ -64,6 +65,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "postcss": "^8.5.1",
+    "prettier": "^3.4.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
   },

--- a/space-agencies.tsx
+++ b/space-agencies.tsx
@@ -15,10 +15,6 @@ interface Agency {
 }
 
 const agencies: Agency[] = [
-
-
- 
-
   {
     id: "nasa",
     name: "004",
@@ -63,9 +59,15 @@ const agencies: Agency[] = [
 
 export default function SpaceAgencies() {
   const [activeAgencyIndex, setActiveAgencyIndex] = useState(4);
+
+  const handleScrollToBottom = () => {
+    if (activeAgencyIndex > 0) {
+      setActiveAgencyIndex(activeAgencyIndex - 1);
+    }
+  };
+
   return (
     <div className="font-['neue-haas-grotesk-display'] flex flex-col md:flex-row">
-
       <div
         className=" w-full h-screen absolute overflow-hidden 
 "
@@ -79,8 +81,8 @@ export default function SpaceAgencies() {
             isTransformed={index > activeAgencyIndex}
             isActive={activeAgencyIndex === index}
             onClick={() => setActiveAgencyIndex(index)}
+            onScrollToBottom={handleScrollToBottom}
           >
-         
             {agency.id === "jaxa" && (
               <div className="flex flex-col justify-between min-h-screen bg-white ">
                 <div className="flex-1 justify-between ">
@@ -119,21 +121,23 @@ export default function SpaceAgencies() {
                     sizes="100vw"
                     priority
                   /> */}
-                  <div className="flex flex-col justify-items-start
-">
-  <p className={`text-sm ${agency.textColor}`}>
-    {agency.name}
-  </p>
+                  <div
+                    className="sticky top-0 flex flex-col justify-items-start
+"
+                  >
+                    <p className={`text-sm ${agency.textColor}`}>
+                      {agency.name}
+                    </p>
 
-  <p
-    className={`text-5xl ${agency.textColor} `}
-  >
-    {agency.title}
-  </p>
-</div>
+                    <p className={`text-5xl ${agency.textColor} `}>
+                      {agency.title}
+                    </p>
+                  </div>
                 </div>
-                <div className="2xl:mr-80 font-martina text-white font-normal text-xl  leading-tight py-40
-text-lgtext-white  ">
+                <div
+                  className="2xl:mr-80 font-martina text-white font-normal text-xl  leading-tight py-40
+text-lgtext-white  "
+                >
                   <p className="p-3">
                     Scale. In science, it’s a word that often connotes size, and
                     usually a massive size. And it’s often bandied about as
@@ -182,22 +186,23 @@ text-lgtext-white  ">
                     priority
                   /> */}
 
-                <div className="flex flex-col justify-items-start
-">
-  <p className={`text-sm ${agency.textColor}`}>
-    {agency.name}
-  </p>
+                  <div
+                    className="flex flex-col justify-items-start
+"
+                  >
+                    <p className={`text-sm ${agency.textColor}`}>
+                      {agency.name}
+                    </p>
 
-  <p
-    className={`text-5xl ${agency.textColor} `}
-  >
-    {agency.title}
-  </p>
-</div>
-
+                    <p className={`text-5xl ${agency.textColor} `}>
+                      {agency.title}
+                    </p>
+                  </div>
                 </div>
-                <div className="2xl:mr-80 text-white  font-martina font-normal text-xl  leading-tight py-40
-">
+                <div
+                  className="2xl:mr-80 text-white  font-martina font-normal text-xl  leading-tight py-40
+"
+                >
                   <p className="p-3">
                     Thirty years ago, the cause of Huntington’s disease was
                     traced to a mutation in the HTT gene. Yet, the precise
@@ -262,20 +267,18 @@ text-lgtext-white  ">
             {agency.id === "esa" && (
               <div className="min-h-screen  lg:mx-40 text-lg leading-tight pt-6 flex flex-col bg-[#DE6079]">
                 <div className="  h-auto my-12">
+                  <div
+                    className="flex flex-col justify-items-start
+"
+                  >
+                    <p className={`text-sm ${agency.textColor}`}>
+                      {agency.name}
+                    </p>
 
-                <div className="flex flex-col justify-items-start
-">
-  <p className={`text-sm ${agency.textColor}`}>
-    {agency.name}
-  </p>
-
-  <p
-    className={`text-5xl ${agency.textColor} `}
-  >
-    {agency.title}
-  </p>
-</div>
-
+                    <p className={`text-5xl ${agency.textColor} `}>
+                      {agency.title}
+                    </p>
+                  </div>
 
                   {/* <Image
                     src="/key-art.png"
@@ -287,10 +290,11 @@ text-lgtext-white  ">
                     priority
                   /> */}
                 </div>
-                
-                <div className="2xl:mr-80  text-white  font-martina font-normal text-xl  leading-tight font-normal leading-tight py-40
-">
 
+                <div
+                  className="2xl:mr-80  text-white  font-martina font-normal text-xl  leading-tight font-normal leading-tight py-40
+"
+                >
                   <p className="p-3">
                     Scientists are developing novel gene- and cell-based
                     therapies for rare diseases, metabolic disorders,
@@ -361,26 +365,21 @@ text-lgtext-white  ">
                   /> */}
                 </div>
 
+                <div
+                  className="flex flex-col justify-items-start
+"
+                >
+                  <p className={`text-sm ${agency.textColor}`}>{agency.name}</p>
 
+                  <p className={`text-5xl ${agency.textColor} `}>
+                    {agency.title}
+                  </p>
+                </div>
 
-
-                <div className="flex flex-col justify-items-start
-">
-  <p className={`text-sm ${agency.textColor}`}>
-    {agency.name}
-  </p>
-
-  <p
-    className={`text-5xl ${agency.textColor} `}
-  >
-    {agency.title}
-  </p>
-</div>
-
-
-
-                <div className=" 2xl:mr-80 text-[#42518C] font-martina font-normal text-xl  leading-tight py-40
-">
+                <div
+                  className=" 2xl:mr-80 text-[#42518C] font-martina font-normal text-xl  leading-tight py-40
+"
+                >
                   <p className="p-3">
                     It’s often said that scientists have cured cancer many times
                     … in mice. Beneath the quip lay the belief that laboratory
@@ -452,19 +451,20 @@ text-lgtext-white  ">
                 </div>
               </div>
             )}
-              <div className="flex flex-col items-center justify-items-start
- h-full">
-  <p className={`text-sm ${agency.textColor} whitespace-nowrap`}>
-    {agency.name}
-  </p>
+            <div
+              className="sticky top-0 flex flex-col items-center justify-items-start
+ h-full"
+            >
+              <p className={`text-sm ${agency.textColor} whitespace-nowrap`}>
+                {agency.name}
+              </p>
 
-  <p
-    className={`flex hidden md:block items-center md:text-3xl text-xl md:font-light font-medium ${agency.textColor} md:mt-4 text-right md:text-vertical md:text-left text-horizontal`}
-  >
-    {agency.title}
-  </p>
-</div>
-
+              <p
+                className={`flex hidden md:block items-center md:text-3xl text-xl md:font-light font-medium ${agency.textColor} md:mt-4 text-right md:text-vertical md:text-left text-horizontal`}
+              >
+                {agency.title}
+              </p>
+            </div>
           </Pane>
         ))}
       </div>


### PR DESCRIPTION
Adds an initial implementation for scrolling between pages. This approaches essentially adds a "trigger" element at bottom of each `Pane`, and once it's scrolled "into view", the active index is updated to the next pane. To prevent the transition from triggering too early, a spacing `div` is added above the trigger. This does create additional empty space at the bottom of each pane.

This is the simplest approach with the way the site is currently built. We also have the option to do something more complicated, where we tie the pane transition directly to the user's scroll position (i.e. as the user scrolls the pane transitions, the faster they scroll, the faster it transitions, etc). This would require a decent amount of refactoring of the panes, as they'd likely need to be absolutely positioned.

Let me know if this works, or if we want to go with something a little more complex!

Also added `prettier` as a dependency for code formatting.