### PR TITLE
Colin's Feedback Round 1

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,57 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Display font */
+@font-face {
+  font-family: "Neue Haas Display";
+  src: url("/fonts/NeueHaasGrotDisp-65Medium.otf") format("opentype");
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Neue Haas Display";
+  src: url("/fonts/NeueHaasGrotDisp-66Medium.otf") format("opentype");
+  font-weight: 600;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Neue Haas Display";
+  src: url("/fonts/NeueHaasGrotDisp-66MediumItalic.otf") format("opentype");
+  font-weight: 600;
+  font-style: italic;
+}
+
+/* Regular font */
+@font-face {
+  font-family: "Martina Plantijn";
+  src: url("/fonts/MartinaPlantijn-Regular.otf") format("opentype");
+  font-weight: normal;
+  font-style: normal;
+}
+
+/* Italic font */
+@font-face {
+  font-family: "Martina Plantijn";
+  src: url("/fonts/MartinaPlantijn-Italic.otf") format("opentype");
+  font-weight: normal;
+  font-style: italic;
+}
+
+/* Mono font */
+@font-face {
+  font-family: "Haas Text Mono";
+  src: url("/fonts/Haas Text Mono-55 Roman.otf") format("opentype");
+  font-weight: normal;
+}
+
+@font-face {
+  font-family: "Haas Text Mono";
+  src: url("/fonts/Haas Text Mono-75 Bold.otf") format("opentype");
+  font-weight: bold;
+}
+
 @layer utilities {
   .text-vertical {
     writing-mode: vertical-rl;
@@ -19,21 +70,28 @@
     -webkit-text-stroke: 4px #344899;
   }
 
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  .hide-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+  /* Hide scrollbar for IE, Edge and Firefox */
+  .hide-scrollbar {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
 
-.popuplayout{
-  display: flex;
-  padding: 30px;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
-  flex-shrink: 0;
-
-}
+  .popuplayout {
+    display: flex;
+    padding: 30px;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    flex-shrink: 0;
+  }
   .popupstyle {
-    background: rgba(0, 71, 255, 0.70);
+    background: rgba(0, 71, 255, 0.7);
     box-shadow: 2px 20px 47px 15px rgba(0, 0, 0, 0.22);
     backdrop-filter: blur(10px);
-
   }
   .accordion {
     position: absolute;
@@ -65,8 +123,6 @@
 }
 
 @layer base {
-
-
   :root {
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;

--- a/components/ui/pane.tsx
+++ b/components/ui/pane.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, type ReactNode } from "react";
-import { useInView } from "react-intersection-observer";
+import { useEffect, useState, useRef, type ReactNode } from "react";
+
+const TAB_WIDTH = 60;
 
 interface PaneProps {
   className?: string;
@@ -7,7 +8,8 @@ interface PaneProps {
   isActive: boolean;
   index: number;
   children: ReactNode;
-  onScrollToBottom: () => void;
+  onScrollToTop?: () => void;
+  onScrollToBottom?: () => void;
   onClick: () => void;
   agency?: {
     name: string;
@@ -17,13 +19,20 @@ interface PaneProps {
 }
 
 function getStyle(isTransformed: boolean, index: number) {
-  const percent = `${index * 3}%`;
+  const percent = `${index * TAB_WIDTH}px`;
+  const width = `calc(100vw - ${TAB_WIDTH * 4}px)`;
   if (isTransformed) {
-    return { right: percent, transform: "translate(-85vw)" };
+    return {
+      right: percent,
+      transform: `translate(calc(-100% + ${TAB_WIDTH}px))`,
+      width,
+    };
   } else {
-    return { right: percent };
+    return { right: percent, width };
   }
 }
+
+const RESISTANCE_THRESHOLD = 600;
 
 export function Pane({
   index,
@@ -31,17 +40,14 @@ export function Pane({
   isTransformed,
   children,
   className,
+  onScrollToTop,
   onScrollToBottom,
   onClick,
   agency,
   ...props
 }: PaneProps) {
   const paneRef = useRef<HTMLDivElement>(null);
-
-  const { ref: bottomRef, inView } = useInView({
-    threshold: 0.5,
-    // triggerOnce: true,
-  });
+  const [overscroll, setOverscroll] = useState(0);
 
   useEffect(() => {
     if (isActive && paneRef.current) {
@@ -50,31 +56,65 @@ export function Pane({
   }, [isActive]);
 
   useEffect(() => {
-    if (inView && onScrollToBottom) {
-      onScrollToBottom();
-    }
-  }, [inView]);
+    const handleScroll = (event: WheelEvent) => {
+      if (!paneRef.current || !isActive) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = paneRef.current;
+      const atTop = scrollTop <= 0;
+      const atBottom = scrollTop + clientHeight >= scrollHeight - 3;
+
+      if (atBottom && event.deltaY > 0) {
+        setOverscroll((prev) =>
+          Math.min(prev + event.deltaY, RESISTANCE_THRESHOLD),
+        );
+      } else if (atTop && event.deltaY < 0) {
+        setOverscroll((prev) =>
+          Math.max(prev + event.deltaY, -RESISTANCE_THRESHOLD),
+        );
+      } else {
+        setOverscroll(0); // Reset overscroll if scrolling normally
+      }
+
+      if (overscroll >= RESISTANCE_THRESHOLD) {
+        onScrollToBottom?.();
+        setOverscroll(0);
+      } else if (overscroll <= -RESISTANCE_THRESHOLD) {
+        onScrollToTop?.();
+        setOverscroll(0);
+      }
+    };
+
+    paneRef.current?.addEventListener("wheel", handleScroll);
+
+    return () => {
+      paneRef.current?.removeEventListener("wheel", handleScroll);
+    };
+  }, [isActive, overscroll]);
 
   return (
     <div
       ref={paneRef}
       style={getStyle(isTransformed, index)}
-      className={`transition duration-700 ease-[cubic-bezier(0.42, 0, 0.58, 1)] ${
+      className={`hide-scrollbar transition duration-800 ease-[cubic-bezier(0.42, 0, 0.58, 1)] ${
         isActive ? "h-screen overflow-auto" : "overflow-hidden h-screen"
-      } ${className ?? ""} min-w-[90vw] p-4 flex`}
+      } ${className ?? ""} p-4 flex`}
       onClick={onClick}
       {...props}
     >
       <div className="flex-grow">
         {children}
-        <div className="h-[150px]" />
-        <div ref={bottomRef} className="h-[100px]" />
+        {index !== 4 && <div className="h-[100px]" />}
       </div>
       {agency && (
-
-        <div role="button" className="sticky cursor-pointer top-0 flex flex-col items-center justify-items-start h-full ml-4">
-          <p className={`text-sm font-neueHaas font-semibold ${agency.textColor} whitespace-nowrap`}>{agency.name}</p>
-
+        <div
+          role="button"
+          className="sticky cursor-pointer top-0 right-0 flex flex-col items-center justify-items-start h-full ml-4"
+        >
+          <p
+            className={`text-sm font-neueHaas font-semibold ${agency.textColor} whitespace-nowrap`}
+          >
+            {agency.name}
+          </p>
 
           <p
             className={`flex hidden md:block items-center md:text-2xl text-xl font-neueHaas font-semibold ${agency.textColor} md:mt-4 text-right md:text-vertical md:text-left text-horizontal`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "react-dom": "^18",
         "react-draggable": "^4.4.6",
         "react-hook-form": "^7.54.1",
-        "react-intersection-observer": "^9.15.1",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
         "sonner": "^1.7.1",
@@ -3161,20 +3160,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-intersection-observer": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.15.1.tgz",
-      "integrity": "sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==",
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-dom": "^18",
     "react-draggable": "^4.4.6",
     "react-hook-form": "^7.54.1",
-    "react-intersection-observer": "^9.15.1",
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
     "sonner": "^1.7.1",

--- a/space-agencies.tsx
+++ b/space-agencies.tsx
@@ -1,21 +1,25 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import { Pane } from "./components/ui/pane"
-import Popup from "./components/ui/popup"
-import Image from "next/image"
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
-import Link from "next/link"
-import ByTheNumbers
- from "./components/ui/byTheNumbers"
+import { useState, useEffect } from "react";
+import { Pane } from "./components/ui/pane";
+import Popup from "./components/ui/popup";
+import Image from "next/image";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import Link from "next/link";
+import ByTheNumbers from "./components/ui/byTheNumbers";
 
 interface Agency {
-  id: string
-  name: string
-  title: string
-  bgColor: string
-  textColor: string
-  accordionClass: string
+  id: string;
+  name: string;
+  title: string;
+  bgColor: string;
+  textColor: string;
+  accordionClass: string;
 }
 
 const agencies: Agency[] = [
@@ -59,33 +63,39 @@ const agencies: Agency[] = [
     textColor: "text-[#344899]",
     accordionClass: "accordion-00",
   },
-]
+];
 
 export default function SpaceAgencies() {
-  const [activeAgencyIndex, setActiveAgencyIndex] = useState(4)
-  const [showPopup, setShowPopup] = useState(true) // State for showing the popup
-  const [isMobile, setIsMobile] = useState(false)
+  const [activeAgencyIndex, setActiveAgencyIndex] = useState(4);
+  const [showPopup, setShowPopup] = useState(true); // State for showing the popup
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth < 768)
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const handleScrollToTop = () => {
+    if (activeAgencyIndex < agencies.length - 1) {
+      setActiveAgencyIndex(activeAgencyIndex + 1);
     }
-
-    window.addEventListener("resize", handleResize)
-    handleResize()
-
-    return () => window.removeEventListener("resize", handleResize)
-  }, [])
+  };
 
   const handleScrollToBottom = () => {
     if (activeAgencyIndex > 0) {
       setActiveAgencyIndex(activeAgencyIndex - 1);
     }
-  }
+  };
 
   const closePopup = () => {
-    setShowPopup(false) // Close the popup when the button is clicked
-  }
+    setShowPopup(false); // Close the popup when the button is clicked
+  };
 
   const renderAgencyContent = (agency: Agency) => {
     switch (agency.id) {
@@ -103,7 +113,7 @@ export default function SpaceAgencies() {
                   sizes="100vw"
                   priority
                 />
-                       <Image
+                <Image
                   src="/differently-mobile.svg"
                   alt="Differently"
                   width={1920}
@@ -112,25 +122,29 @@ export default function SpaceAgencies() {
                   sizes="100vw"
                   priority
                 />
-
               </div>
               <div className="font-neueHaas mx-1 text-[#344899]">
-              <div className="leading-[2em] ">
-                <h2 className="text-xl  font-semibold">Broad Institute</h2>
-                {/* <h3 className="text-xl font-semibold">Year in Review 2024</h3> */}
-                <div className="flex flex-col md:flex-row justify-between  text-[#344899]">
-                <div className="font-semibold hidden md:block">Scroll to read</div>
-       
-                <Link href="/about">  <div className="font-bold md:py-0 py-2 hover:underline"> About this site </div></Link>
-              </div>
-              </div>
+                <div className="leading-[2em] ">
+                  <h2 className="text-xl  font-semibold">Broad Institute</h2>
+                  {/* <h3 className="text-xl font-semibold">Year in Review 2024</h3> */}
+                  <div className="flex flex-col md:flex-row justify-between  text-[#344899]">
+                    <div className="font-semibold hidden md:block">
+                      Scroll to read
+                    </div>
+
+                    <Link href="/about">
+                      {" "}
+                      <div className="font-bold md:py-0 py-2 hover:underline">
+                        {" "}
+                        About this site{" "}
+                      </div>
+                    </Link>
+                  </div>
+                </div>
               </div>
             </div>
-          
           </div>
-
-
-        )
+        );
       case "intro":
         return (
           <div className="min-h-screen mx-2 lg:mx-40  pt-6 flex flex-col bg-[#292D74] ">
@@ -139,311 +153,466 @@ export default function SpaceAgencies() {
                 className="sticky top-0 flex flex-col justify-items-start
 "
               >
-                <p className={`text-sm font-neueHaas ${agency.textColor}`}>{agency.name}</p>
+                <p className={`text-sm font-neueHaas ${agency.textColor}`}>
+                  {agency.name}
+                </p>
 
-                <h1 className={`text-5xl md:px-0 px-3 font-neueHaas ${agency.textColor} `}>{agency.title}</h1>
+                <h1
+                  className={`text-5xl md:px-0 px-3 font-neueHaas ${agency.textColor} `}
+                >
+                  {agency.title}
+                </h1>
               </div>
             </div>
-            <article 
+            <article
               className=" font-martina prose  text-white font-normal text-xl leading-6 py-40
-text-lg   " role="main"
+text-lg   "
+              role="main"
             >
               <p className="py-3">
-                Scale. In science, it’s a word that often connotes size, and usually a massive size. And it’s often
-                bandied about as genomic and other technologies produce ever-growing reams of data and cutting-edge
-                computational approaches are trained to interpret them. Sequencing centers are churning out hundreds of
-                thousands of genomes a day. Laboratories are now able to profile millions of cells in an experiment.
-                Machine learning is scanning many millions of medical images to find new patterns.
+                Scale. In science, it’s a word that often connotes size, and
+                usually a massive size. And it’s often bandied about as genomic
+                and other technologies produce ever-growing reams of data and
+                cutting-edge computational approaches are trained to interpret
+                them. Sequencing centers are churning out hundreds of thousands
+                of genomes a day. Laboratories are now able to profile millions
+                of cells in an experiment. Machine learning is scanning many
+                millions of medical images to find new patterns.
               </p>
 
-     <div className=" font-sans font-semibold border rounded-full border-4 p-5">
-                But at the Broad Institute, scale means something different. 
-                </div>
-                
-                <p className="py-3">
-                It’s more than just size—it’s about taking
-                systematic, unbiased approaches and going where the data leads you. It’s about traversing reams of
-                cellular data and uncovering a lead that could someday help solve a medical mystery. It’s about sifting
-                through millions of proteins to build one that could someday be a new gene-editing tool. Or taking
-                everything we know about the genetic changes cancer cells undergo, figuring out which ones they need to
-                survive, and giving access to the research community so we can get to clinical trials more quickly and
-                more safely for patients.
+              <div className=" font-sans font-semibold border rounded-full border-4 p-5">
+                But at the Broad Institute, scale means something different.
+              </div>
+
+              <p className="py-3">
+                It’s more than just size—it’s about taking systematic, unbiased
+                approaches and going where the data leads you. It’s about
+                traversing reams of cellular data and uncovering a lead that
+                could someday help solve a medical mystery. It’s about sifting
+                through millions of proteins to build one that could someday be
+                a new gene-editing tool. Or taking everything we know about the
+                genetic changes cancer cells undergo, figuring out which ones
+                they need to survive, and giving access to the research
+                community so we can get to clinical trials more quickly and more
+                safely for patients.
               </p>
               <p className="py-3">
-                And it’s one of the many ways the Broad community continues to forge its own distinct path to scientific
-                breakthroughs that may someday transform medicine. We invite you to join us on this journey and learn
-                more about our work here.
+                And it’s one of the many ways the Broad community continues to
+                forge its own distinct path to scientific breakthroughs that may
+                someday transform medicine. We invite you to join us on this
+                journey and learn more about our work here.
               </p>
             </article>
           </div>
-        )
+        );
       case "roscosmos":
         return (
           <div className="min-h-screen items-center mx-2 lg:mx-40 bg-[#4773CD] leading-tight  flex flex-col ">
             <div className=" w-full h-auto mb-12">
-                    <Image
+              <Image
                 src="/story-1.png"
                 alt="A New Perspective on a Decades-old Mystery"
                 width={1920}
                 height={640}
                 className="object-cover hidden md:block"
                 sizes="100vw"
-                priority/>
+                priority
+              />
 
-          <Image
+              <Image
                 src="/story-1-mobile.png"
                 alt="A New Perspective on a Decades-old Mystery"
                 width={1920}
                 height={640}
                 className="object-cover md:hidden block"
                 sizes="100vw"
-                priority/>
-                
-  
+                priority
+              />
             </div>
 
             <div className="">
-            <article role="main"
-              className="prose justify-center text-white   lg:mx-40   mx-2 font-martina font-normal text-xl pb-32  leading-6 
+              <article
+                role="main"
+                className="prose justify-center text-white   lg:mx-40   mx-2 font-martina font-normal text-xl pb-32  leading-6 
 "
-            >
-                          <h2 className="py-5 text-[#D3BBDB] text-2xl font-neueHaas font-semibold">Broad scientists have unlocked new therapeutic possibilities for Huntington’s disease.</h2>
+              >
+                <h2 className="py-5 text-[#D3BBDB] text-2xl font-neueHaas font-semibold">
+                  Broad scientists have unlocked new therapeutic possibilities
+                  for Huntington’s disease.
+                </h2>
 
-              <p className="py-3">
-              Thirty years ago, the cause of Huntington’s disease was traced to a mutation in the <span className="italic">HTT</span> gene. Yet, the precise mechanism by which this mutation causes brain cells to die remained elusive. The prevailing thought was that the mutation produces a toxic protein that gradually accumulates, ultimately killing neurons. Research from Steve McCarroll, a Broad investigator, and his team offers a new take—one that not only rewrites the basic biology of the disease but also unlocks new therapeutic possibilities. 
-              </p>
+                <p className="py-3">
+                  Thirty years ago, the cause of Huntington’s disease was traced
+                  to a mutation in the <span className="italic">HTT</span> gene.
+                  Yet, the precise mechanism by which this mutation causes brain
+                  cells to die remained elusive. The prevailing thought was that
+                  the mutation produces a toxic protein that gradually
+                  accumulates, ultimately killing neurons. Research from Steve
+                  McCarroll, a Broad investigator, and his team offers a new
+                  take—one that not only rewrites the basic biology of the
+                  disease but also unlocks new therapeutic possibilities.
+                </p>
 
-              <p className="py-3">
-              The true culprit may lie not in the protein itself but in the gene’s behavior—specifically, the phenomenon of <span className="italic">somatic instability</span>, a subtle genetic anomaly first observed in animal models in the late 1990s. In Huntington’s patients, a repeating DNA sequence—CAG—expands unpredictably as the disease progresses, and it is this expansion, McCarroll and his team believe, that drives the degeneration of the brain’s motor centers. 
-              </p>
-              <p className="py-3">
-              Yet for much of the last three decades, the field has largely overlooked this clue, fixated instead on the role of the protein. But new technologies allow researchers to zoom in and discover what is happening to affected brain cells.
+                <p className="py-3">
+                  The true culprit may lie not in the protein itself but in the
+                  gene’s behavior—specifically, the phenomenon of{" "}
+                  <span className="italic">somatic instability</span>, a subtle
+                  genetic anomaly first observed in animal models in the late
+                  1990s. In Huntington’s patients, a repeating DNA
+                  sequence—CAG—expands unpredictably as the disease progresses,
+                  and it is this expansion, McCarroll and his team believe, that
+                  drives the degeneration of the brain’s motor centers.
+                </p>
+                <p className="py-3">
+                  Yet for much of the last three decades, the field has largely
+                  overlooked this clue, fixated instead on the role of the
+                  protein. But new technologies allow researchers to zoom in and
+                  discover what is happening to affected brain cells.
+                </p>
+                <p className="py-3">
+                  McCarroll and his team specifically used a technology they
+                  developed known as Drop-seq—which allows them to individually
+                  profile many thousands of cells—to track the precise length of
+                  these CAG repeats in individual cells, providing a level of
+                  granularity previously unavailable. By analyzing over half a
+                  million cells from healthy and Huntington’s-affected brains,
+                  they discovered that striatal projection neurons—the cells
+                  most affected by the disease—were the only ones to show a
+                  significant expansion of these repeats. Once the expansion
+                  surpasses around 150 repeats, these neurons begin to
+                  deteriorate, setting in motion the hallmark symptoms of
+                  Huntington’s: involuntary movements, cognitive decline, and
+                  loss of motor function.
+                  <p className="py-3">
+                    The discovery, published in{" "}
+                    <span className="italic"> Cell</span>, fundamentally alters
+                    the way we think about Huntington’s disease. It also
+                    explains why decades of drug development have failed to
+                    materialize an effective treatment for the disease: they
+                    were chasing the wrong target. A more promising therapeutic
+                    strategy could involve slowing or halting the expansion of
+                    the CAG repeats. Such an approach might delay the onset of
+                    the disease or even arrest its progression, offering
+                    long-awaited hope for thousands of patients.
+                  </p>
+                </p>
+                <Image
+                  src="/story-1-illu.png"
+                  alt="Huntington (HTT) Gene Somatic Instability"
+                  width={1920}
+                  height={640}
+                  className="object-cover hidden md:block"
+                  sizes="100vw"
+                  priority
+                />
 
-              </p>
-              <p className="py-3">
-              McCarroll and his team specifically used a technology they developed known as Drop-seq—which allows them to individually profile many thousands of cells—to track the precise length of these CAG repeats in individual cells, providing a level of granularity previously unavailable. By analyzing over half a million cells from healthy and Huntington’s-affected brains, they discovered that striatal projection neurons—the cells most affected by the disease—were the only ones to show a significant expansion of these repeats. Once the expansion surpasses around 150 repeats, these neurons begin to deteriorate, setting in motion the hallmark symptoms of Huntington’s: involuntary movements, cognitive decline, and loss of motor function.
-             
-              <p className="py-3">
-                The discovery, published in <span className="italic"> Cell</span>, fundamentally alters the way we think about Huntington’s disease. It also explains why decades of drug development have failed to materialize an effective treatment for the disease: they were chasing the wrong target. A more promising therapeutic strategy could involve slowing or halting the expansion of the CAG repeats. Such an approach might delay the onset of the disease or even arrest its progression, offering long-awaited hope for thousands of patients.  
-              </p>
-              </p>
-              <Image
-                src="/story-1-illu.png"
-                alt="Huntington (HTT) Gene Somatic Instability"
-                width={1920}
-                height={640}
-                className="object-cover hidden md:block"
-                sizes="100vw"
-                priority/>
-
-          <Image
-                src="/story-1-illu-mobile.png"
-                alt="Huntingtin (HTT) Gene Somatic Instability"
-                width={1920}
-                height={640}
-                className="object-cover md:hidden block"
-                sizes="100vw"
-                priority/>
-                <figcaption className=" font-mono text-sm text-white"><h4 className="font-mono text-white">HOW IT WORKS</h4>
-                In Huntington’s patients, a repeating DNA sequence — CAG — expands unpredictably as the disease progresses, and it is this expansion, McCarroll and his team believe, that drives the degeneration of the brain’s motor centers.</figcaption>
-                
-           
-            </article>
+                <Image
+                  src="/story-1-illu-mobile.png"
+                  alt="Huntingtin (HTT) Gene Somatic Instability"
+                  width={1920}
+                  height={640}
+                  className="object-cover md:hidden block"
+                  sizes="100vw"
+                  priority
+                />
+                <figcaption className=" font-mono text-sm text-white">
+                  <h4 className="font-mono text-white">HOW IT WORKS</h4>
+                  In Huntington’s patients, a repeating DNA sequence — CAG —
+                  expands unpredictably as the disease progresses, and it is
+                  this expansion, McCarroll and his team believe, that drives
+                  the degeneration of the brain’s motor centers.
+                </figcaption>
+              </article>
             </div>
           </div>
-        )
+        );
       case "esa":
         return (
           <div className="min-h-screen items-center lg:mx-40 mx-2 text-lg leading-tight  flex flex-col bg-[#DA2F62]">
-                  <div className=" w-full h-auto mb-12">
-                    <Image
+            <div className=" w-full h-auto mb-12">
+              <Image
                 src="/story-2.png"
                 alt="Eye of the Needle"
                 width={1920}
                 height={640}
                 className="object-cover hidden md:block"
                 sizes="100vw"
-                priority/>
-   <Image
+                priority
+              />
+              <Image
                 src="/story-2-mobile.png"
                 alt="Eye of the Needle"
                 width={1920}
                 height={640}
                 className="object-cover md:hidden block"
                 sizes="100vw"
-                priority/>
-              
+                priority
+              />
             </div>
 
             <div className="">
-
-            <article role="main"
-              className="prose  justify-center text-white  font-martina font-normal text-xl pb-32  leading-6
+              <article
+                role="main"
+                className="prose  justify-center text-white  font-martina font-normal text-xl pb-32  leading-6
 "
-            >
-                          <h2 className="py-5 text-white text-2xl font-neueHaas font-semibold">A promising gene-editing tool inspired by a bacterial syringe.</h2>
+              >
+                <h2 className="py-5 text-white text-2xl font-neueHaas font-semibold">
+                  A promising gene-editing tool inspired by a bacterial syringe.
+                </h2>
 
-              <p className="py-3">
-              Scientists are developing novel gene- and cell-based therapies for rare diseases, metabolic disorders, cardiovascular conditions, cancers, and more. But these therapies still face a major hurdle: they need to reach the right disease-causing cells in the body. 
+                <p className="py-3">
+                  Scientists are developing novel gene- and cell-based therapies
+                  for rare diseases, metabolic disorders, cardiovascular
+                  conditions, cancers, and more. But these therapies still face
+                  a major hurdle: they need to reach the right disease-causing
+                  cells in the body.
+                </p>
 
-              </p>
+                <p className="py-3">
+                  Current technologies can deliver gene therapies to some
+                  tissues, such as the eye, blood, and liver, but not others,
+                  especially crucial locations like the brain, heart, lung, and
+                  kidney. As part of an ambitious initiative to build a suite of
+                  modular tools that researchers can quickly—and
+                  scalably—repurpose to design gene-editing therapies that
+                  strike at the root causes of diseases, Broad researcher Feng
+                  Zhang is tackling this bottleneck with a new delivery vehicle
+                  that can ferry gene-editing tools to different cell types.
+                </p>
 
-              <p className="py-3">
-              Current technologies can deliver gene therapies to some tissues, such as the eye, blood, and liver, but not others, especially crucial locations like the brain, heart, lung, and kidney. As part of an ambitious initiative to build a suite of modular tools that researchers can quickly—and scalably—repurpose to design gene-editing therapies that strike at the root causes of diseases, Broad researcher Feng Zhang is tackling this bottleneck with a new delivery vehicle that can ferry gene-editing tools to different cell types.
-              </p>
+                <Image
+                  src="/story-2-illu.png"
+                  alt="extra-cellular contractile injection system"
+                  width={1920}
+                  height={640}
+                  className="object-cover hidden md:block"
+                  sizes="100vw"
+                  priority
+                />
 
+                <Image
+                  src="/story-2-illu-mobile.png"
+                  alt="extra-cellular contractile injection system"
+                  width={1920}
+                  height={640}
+                  className="object-cover md:hidden block"
+                  sizes="100vw"
+                  priority
+                />
+                <figcaption className=" font-mono text-sm text-white">
+                  <h4 className="font-mono text-white">HOW IT WORKS</h4>
+                  In eCIS, a tiny syringe-like tube injects proteins into host
+                  cells. On one end of eCIS are tail fibers that recognize
+                  specific receptors on the cell surface and latch on.{" "}
+                </figcaption>
 
-              <Image
-                src="/story-2-illu.png"
-                alt="extra-cellular contractile injection system"
-                width={1920}
-                height={640}
-                className="object-cover hidden md:block"
-                sizes="100vw"
-                priority/>
-
-          <Image
-                src="/story-2-illu-mobile.png"
-                alt="extra-cellular contractile injection system"
-                width={1920}
-                height={640}
-                className="object-cover md:hidden block"
-                sizes="100vw"
-                priority/>
-                <figcaption className=" font-mono text-sm text-white"><h4 className="font-mono text-white">HOW IT WORKS</h4>
-                In eCIS, a tiny syringe-like tube injects proteins into host cells. On one end of eCIS are tail fibers that recognize specific receptors on the cell surface and latch on.     </figcaption>           
-
-              
-              <p className="py-3">
-              With the support of a group of philanthropists, he and his team are doing this by plumbing nature’s secrets. In this case, they have refashioned a natural feature of <span className="italic"> Photorhabdus </span> bacteria called eCIS—extracellular contractile injection system—in which a tiny syringe-like tube injects proteins into host cells. On one end of the eCIS are tail fibers that recognize specific receptors on the cell surface and latch on. Though eCISs naturally only target insect and mouse cells, using AlphaFold—an AI program that predicts the shape of proteins and has so far catalogued more than 200 million protein structures—the Zhang Lab reengineered the tail fibers of the eCIS to bind to human cells and tricked the syringe into delivering a protein of the lab’s choosing.
-              </p>
-              <p className="py-3">
-              Thus far, the reengineered eCIS machines have shown their versatility, delivering different types of proteins to human cells. These include base editors, which can make single-letter changes to DNA; proteins that are toxic to cancer cells; and Cas9, a large DNA-cutting enzyme used in CRISPR gene-editing systems. The team even deployed an eCIS to deliver proteins into the brains of live mice. It’s a major step forward for developing future gene therapies to the brain, one of the most challenging parts of the body to target.
-
-              </p>
-              <p className="py-3">
-          
-The potential is immense, and the team is working to realize it by optimizing their eCIS systems while also exploring other promising delivery approaches. 
-
-              </p>
+                <p className="py-3">
+                  With the support of a group of philanthropists, he and his
+                  team are doing this by plumbing nature’s secrets. In this
+                  case, they have refashioned a natural feature of{" "}
+                  <span className="italic"> Photorhabdus </span> bacteria called
+                  eCIS—extracellular contractile injection system—in which a
+                  tiny syringe-like tube injects proteins into host cells. On
+                  one end of the eCIS are tail fibers that recognize specific
+                  receptors on the cell surface and latch on. Though eCISs
+                  naturally only target insect and mouse cells, using
+                  AlphaFold—an AI program that predicts the shape of proteins
+                  and has so far catalogued more than 200 million protein
+                  structures—the Zhang Lab reengineered the tail fibers of the
+                  eCIS to bind to human cells and tricked the syringe into
+                  delivering a protein of the lab’s choosing.
+                </p>
+                <p className="py-3">
+                  Thus far, the reengineered eCIS machines have shown their
+                  versatility, delivering different types of proteins to human
+                  cells. These include base editors, which can make
+                  single-letter changes to DNA; proteins that are toxic to
+                  cancer cells; and Cas9, a large DNA-cutting enzyme used in
+                  CRISPR gene-editing systems. The team even deployed an eCIS to
+                  deliver proteins into the brains of live mice. It’s a major
+                  step forward for developing future gene therapies to the
+                  brain, one of the most challenging parts of the body to
+                  target.
+                </p>
+                <p className="py-3">
+                  The potential is immense, and the team is working to realize
+                  it by optimizing their eCIS systems while also exploring other
+                  promising delivery approaches.
+                </p>
               </article>
             </div>
           </div>
-        )
+        );
       case "nasa":
         return (
           <div className="min-h-screen items-center lg:mx-40 mx-2 text-lg leading-tight  flex flex-col bg-[#CED7E9]">
-                      <div className=" w-full h-auto mb-12">
-                    <Image
+            <div className=" w-full h-auto mb-12">
+              <Image
                 src="/story-3.png"
                 alt="DepMap and Patient Impact"
                 width={1920}
                 height={640}
                 className="object-cover hidden md:block"
                 sizes="100vw"
-                priority/>
-                  <Image
+                priority
+              />
+              <Image
                 src="/story-3-mobile.png"
                 alt="DepMap and Patient Impact"
                 width={1920}
                 height={640}
                 className="object-cover md:hidden block"
                 sizes="100vw"
-                priority/>
-                
-
+                priority
+              />
             </div>
-
 
             <div className="">
-
-            <article role="main"
-              className="prose  justify-center text-[#344899] font-martina font-normal text-xl pb-32  leading-6
+              <article
+                role="main"
+                className="prose  justify-center text-[#344899] font-martina font-normal text-xl pb-32  leading-6
 "
-            >
-                            <h2 className="py-5 text-2xl text-[#344899] font-neueHaas font-semibold">A Broad-led effort to understand the molecular diversity of tumors is leading to new clinical trials.</h2>
+              >
+                <h2 className="py-5 text-2xl text-[#344899] font-neueHaas font-semibold">
+                  A Broad-led effort to understand the molecular diversity of
+                  tumors is leading to new clinical trials.
+                </h2>
 
-              <p className="py-3">
-              It’s often said that scientists have cured cancer many times… in mice. Beneath the quip lay the belief that laboratory models of cancer were all imperfect, and therefore, scientists shouldn’t agonize over validating a therapeutic hypothesis—they just needed to move quickly to get drugs to cancer patients. 
-              </p>
+                <p className="py-3">
+                  It’s often said that scientists have cured cancer many times…
+                  in mice. Beneath the quip lay the belief that laboratory
+                  models of cancer were all imperfect, and therefore, scientists
+                  shouldn’t agonize over validating a therapeutic
+                  hypothesis—they just needed to move quickly to get drugs to
+                  cancer patients.
+                </p>
 
-              <p className="py-3">
-              But there’s a major glitch: most drugs fail in clinical trials. Even amid breakthroughs in cancer treatments, up to 95 percent of experimental oncology drugs still never make it to patients. That’s an astonishing waste of resources—and it unnecessarily exposes cancer patients to sometimes grueling treatments.
+                <p className="py-3">
+                  But there’s a major glitch: most drugs fail in clinical
+                  trials. Even amid breakthroughs in cancer treatments, up to 95
+                  percent of experimental oncology drugs still never make it to
+                  patients. That’s an astonishing waste of resources—and it
+                  unnecessarily exposes cancer patients to sometimes grueling
+                  treatments.
+                </p>
+                <p className="py-3">
+                  With the advent of genomic sequencing, scientists realized
+                  that the central problem in finding effective new cancer drugs
+                  wasn’t so much that models were imperfect, but that cancer
+                  isn’t a single disease. Instead, it’s a collection of
+                  molecularly distinct diseases. So taking a single cell line—
+                  “immortalized” cells that grow in Petri dishes and are the
+                  workhorse of cancer research—and applying it to a range of
+                  cancers was a recipe for failure.
+                </p>
+                <p className="py-3">
+                  Thus, Broad cancer researchers and their collaborators
+                  (notably those at the Wellcome Sanger Institute in the U.K.)
+                  reasoned they could use the latest genomic and other advanced
+                  technologies to create a new resource that captured the
+                  molecular diversity of actual human tumors. They also reckoned
+                  they could pinpoint tumors’ weak spots—genetic anomalies found
+                  only in cancer cells and necessary for their survival, and
+                  thus, perfect drug targets. They began collecting existing
+                  cell lines—and generated new ones—profiled them genomically,
+                  and then systematically made genetic tweaks (e.g., deleted or
+                  dialed down genes) to identify molecular vulnerabilities, or
+                  dependencies. And they also subjected the cell lines to
+                  thousands of drug treatments to see whether any possible
+                  treatments already existed.
+                </p>
 
-              </p>
-              <p className="py-3">
-              With the advent of genomic sequencing, scientists realized that the central problem in finding effective new cancer drugs wasn’t so much that models were imperfect, but that 
-cancer isn’t a single disease. Instead, it’s a collection of molecularly distinct diseases. So taking a single cell line— “immortalized” cells that grow in Petri dishes and are the workhorse of cancer research—and applying it to a range of cancers was a recipe for failure.
+                <Image
+                  src="/story-3-illu.png"
+                  alt="Clinical Trials for Experimental Oncology Drugs"
+                  width={1920}
+                  height={640}
+                  className="object-cover hidden md:block"
+                  sizes="100vw"
+                  priority
+                />
 
-              </p>
-              <p className="py-3">
-              Thus, Broad cancer researchers and their collaborators (notably those at the Wellcome Sanger Institute in the U.K.) reasoned they could use the latest genomic and other advanced technologies to create a new resource that captured the molecular diversity of actual human tumors. They also reckoned they could pinpoint tumors’ weak spots—genetic anomalies found only in cancer cells and necessary for their survival, and thus, perfect drug targets. They began collecting existing cell lines—and generated new ones—profiled them genomically, and then systematically made genetic tweaks (e.g., deleted or dialed down genes) to identify molecular vulnerabilities, or dependencies. And they also subjected the cell lines to thousands of drug treatments to see whether any possible treatments already existed.
-              </p>
+                <Image
+                  src="/story-3-illu-mobile.png"
+                  alt="Clinical Trials for Experimental Oncology Drugs"
+                  width={1920}
+                  height={640}
+                  className="object-cover md:hidden block"
+                  sizes="100vw"
+                  priority
+                />
+                <figcaption className=" text-[#344899] text-sm font-mono">
+                  <h4 className="text-[#344899] font-mono ">
+                    EVEN AMID BREAKTHROUGHS
+                  </h4>
+                  Most drugs fail in clinical trials. Up to 95% of experimental
+                  oncology drugs never make it to patients.
+                </figcaption>
 
+                <p className="py-3">
+                  These collective efforts, many of which were catalyzed by
+                  philanthropy, were dubbed the Cancer Dependency Map.
+                  Officially launched in 2018, the DepMap has profiled 2,000
+                  cell lines (representing more than 34 cancers) and conducted
+                  around 2 million genome-wide screens.
+                </p>
+                <p className="py-3">
+                  And it’s become a hallmark Broad-led effort: one that not only
+                  takes an unbiased, data-driven approach, but rallies together
+                  researchers to parse through and ultimately, to actively
+                  contribute data. Open to researchers, the DepMap portal, which
+                  also includes analytical tools, boasts more than 11,000 users
+                  a week from across the world. And it also now includes 19
+                  pharmaceutical companies, who make up the DepMap Consortium,
+                  which supports the overall effort.
+                </p>
+                <p className="py-3">
+                  Above all, it’s leading to a real impact on patients,
+                  validating identified targets (a key step in persuading drug
+                  companies to take them up) and uncovering new ones. So far,
+                  seven clinical trials have emerged from the DepMap, with many
+                  more expected in the coming years.
+                </p>
 
-              <Image
-                src="/story-3-illu.png"
-                alt="Clinical Trials for Experimental Oncology Drugs"
-                width={1920}
-                height={640}
-                className="object-cover hidden md:block"
-                sizes="100vw"
-                priority/>
+                <p className="py-3">
+                  Here’s one example of a new target that emerged from the
+                  DepMap: Some cancers have a feature called{" "}
+                  <span className="italic">microsatellite instability</span>{" "}
+                  (MSI), which causes runaway mutation when a DNA repair system
+                  in a cell is broken. About half of cancers with MSI can be
+                  treated with drugs called checkpoint inhibitors that unleash
+                  the patient’s immune system to kill cancer cells. But Broad
+                  and Wellcome Sanger scientists wanted to find ways of
+                  targeting the ones that didn’t respond. Using the DepMap
+                  approach, they discovered that these cancers also depend on a
+                  gene called <span className="italic">WRN,</span> which encodes
+                  a protein that helps cells copy or read DNA by unwinding and
+                  unzipping the genome’s double helix.
+                </p>
 
-
-          <Image
-                src="/story-3-illu-mobile.png"
-                alt="Clinical Trials for Experimental Oncology Drugs"
-                width={1920}
-                height={640}
-                className="object-cover md:hidden block"
-                sizes="100vw"
-                priority/>
-                <figcaption className=" text-[#344899] text-sm font-mono"><h4 className="text-[#344899] font-mono ">EVEN AMID BREAKTHROUGHS</h4>
-                Most drugs fail in clinical trials. Up to 95% of experimental oncology drugs never make it to patients.
-               </figcaption>           
-
-
-
-
-              <p className="py-3">
-              These collective efforts, many of which were catalyzed by philanthropy, were dubbed the Cancer Dependency Map. Officially launched in 2018, the DepMap has profiled 2,000 cell lines (representing more than 34 cancers) and conducted around 2 million genome-wide screens. 
-
-              </p>
-              <p className="py-3">
-              And it’s become a hallmark Broad-led effort: one that not only takes an unbiased, data-driven approach, but rallies together researchers to parse through and ultimately, to actively contribute data. Open to researchers, the DepMap portal, which also includes analytical tools, boasts more than 11,000 users a week from across the world. And it 
-also now includes 19 pharmaceutical companies, who make up the DepMap Consortium, which supports the overall effort.  
-              </p>
-              <p className="py-3">
-              Above all, it’s leading to a real impact on patients, validating identified targets (a key step in persuading 
-drug companies to take them up) and uncovering new ones. So far, seven clinical trials have emerged from the DepMap, with many more expected in the coming years.   
-
-              </p>
-
-
-
-              <p className="py-3">
-              Here’s one example of a new target that emerged from the DepMap: Some cancers have a feature called <span className="italic">microsatellite instability</span> (MSI), which causes runaway mutation when 
-a DNA repair system in a cell is broken. About half of cancers with MSI can be treated with drugs called checkpoint inhibitors that unleash the patient’s immune system to kill cancer cells. But Broad and Wellcome Sanger scientists wanted to find ways of targeting the ones that didn’t respond. Using the DepMap approach, they discovered that these cancers also depend on a gene called <span className="italic">WRN,</span> which encodes a protein that helps cells copy or read DNA by unwinding 
-and unzipping the genome’s double helix. 
-              </p>
-
-         
-
-              <p className="py-3">
-              The scientists uncovered this dependency by looking at two datasets, the DepMap and Project DRIVE (an initiative of the Novartis Institute for Biomedical Research). Both datasets were generated by individually breaking or silencing thousands of genes in cancer cell lines and measuring the resulting effects on cell survival. Among the datasets, the team identified 51 cell lines classified as having MSI. Of those, they then found that 73 percent of them were dependent on <span className="italic">WRN.</span> Now, at least three companies are currently working on drugs to shut down <span className="italic">WRN,</span> which should have no effect on normal cells.               </p>
-
-
-
+                <p className="py-3">
+                  The scientists uncovered this dependency by looking at two
+                  datasets, the DepMap and Project DRIVE (an initiative of the
+                  Novartis Institute for Biomedical Research). Both datasets
+                  were generated by individually breaking or silencing thousands
+                  of genes in cancer cell lines and measuring the resulting
+                  effects on cell survival. Among the datasets, the team
+                  identified 51 cell lines classified as having MSI. Of those,
+                  they then found that 73 percent of them were dependent on{" "}
+                  <span className="italic">WRN.</span> Now, at least three
+                  companies are currently working on drugs to shut down{" "}
+                  <span className="italic">WRN,</span> which should have no
+                  effect on normal cells.{" "}
+                </p>
               </article>
-<ByTheNumbers/>
+              <ByTheNumbers />
             </div>
           </div>
-        )
+        );
       default:
-        return null
+        return null;
     }
-  }
+  };
 
   return (
     <div className="font-neueHaas flex flex-col md:flex-row">
@@ -454,17 +623,23 @@ and unzipping the genome’s double helix.
           <>
             {renderAgencyContent(agencies[4])} {/* Render "jaxa" content */}
             <Accordion type="single" collapsible className="w-full">
-              {agencies.slice(0, 4).toReversed().map((agency, index) => (
-                
-                <AccordionItem key={agency.id} value={agency.id}>
-                  <AccordionTrigger className={`${agency.bgColor} ${agency.textColor} py-5 px-3`}>
-                    {agency.title}
-                  </AccordionTrigger>
-                  <AccordionContent className={`${agency.bgColor} ${agency.textColor}`}>
-                    {renderAgencyContent(agency)}
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
+              {agencies
+                .slice(0, 4)
+                .toReversed()
+                .map((agency, index) => (
+                  <AccordionItem key={agency.id} value={agency.id}>
+                    <AccordionTrigger
+                      className={`${agency.bgColor} ${agency.textColor} py-5 px-3`}
+                    >
+                      {agency.title}
+                    </AccordionTrigger>
+                    <AccordionContent
+                      className={`${agency.bgColor} ${agency.textColor}`}
+                    >
+                      {renderAgencyContent(agency)}
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
             </Accordion>
           </>
         ) : (
@@ -474,11 +649,11 @@ and unzipping the genome’s double helix.
                 <Pane
                   index={index}
                   key={agency.id}
-                  accordionClass={agency.accordionClass}
                   className={`${agency.bgColor} accordion`}
                   isTransformed={index > activeAgencyIndex}
                   isActive={activeAgencyIndex === index}
                   onClick={() => setActiveAgencyIndex(index)}
+                  onScrollToTop={handleScrollToTop}
                   onScrollToBottom={handleScrollToBottom}
                   agency={{
                     name: agency.name,
@@ -493,6 +668,5 @@ and unzipping the genome’s double helix.
         )}
       </div>
     </div>
-  )
+  );
 }
-

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,63 +6,6 @@ body {
   font-family: Neue Haas Display;
 }
 
-
-/* Display font */
-@font-face {
-  font-family: 'Neue Haas Display';
-  src: url('/fonts/NeueHaasGrotDisp-65Medium.otf') format('opentype');
-  font-weight: 300;
-  font-style: normal;
-
-}
-
-@font-face {
-  font-family: 'Neue Haas Display';
-  src: url('/fonts/NeueHaasGrotDisp-66Medium.otf') format('opentype');
-font-weight: 600;
-font-style: normal;
-
-}
-
-@font-face {
-  font-family: 'Neue Haas Display';
-  src: url('/fonts/NeueHaasGrotDisp-66MediumItalic.otf') format('opentype');
-font-weight: 600;
-font-style: italic;
-
-}
-
-/* Regular font */
-@font-face {
-  font-family: 'Martina Plantijn';
-  src: url('/fonts/MartinaPlantijn-Regular.otf') format('opentype');
-  font-weight: normal;
-  font-style: normal;
-}
-
-/* Italic font */
-@font-face {
-  font-family: 'Martina Plantijn';
-  src: url('/fonts/MartinaPlantijn-Italic.otf') format('opentype');
-  font-weight: normal;
-  font-style: italic;
-}
-
-
-/* Mono font */
-@font-face {
-  font-family: 'Haas Text Mono';
-  src: url('/fonts/Haas Text Mono-55 Roman.otf') format('opentype');
-  font-weight: normal;
-}
-
-@font-face {
-  font-family: 'Haas Text Mono';
-  src: url('/fonts/Haas Text Mono-75 Bold.otf') format('opentype');
-  font-weight: bold; 
-}
-
-
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,11 +10,10 @@ const config: Config = {
   ],
   theme: {
     fontFamily: {
-      sans: ["Neue Haas Display",'sans-serif'],
-      neueHaas: ["Neue Haas Display",'sans-serif'],
-      martina: ["Martina Plantijn", 'serif'], // 'serif' is a fallback in case the font isn't loaded
-      mono: ["Haas Text Mono", 'monospace'],
-
+      sans: ["Neue Haas Display", "sans-serif"],
+      neueHaas: ["Neue Haas Display", "sans-serif"],
+      martina: ["Martina Plantijn", "serif"], // 'serif' is a fallback in case the font isn't loaded
+      mono: ["Haas Text Mono", "monospace"],
     },
     extend: {
       colors: {
@@ -96,10 +95,11 @@ const config: Config = {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      transitionDuration: {
+        "800": "800ms",
+      },
     },
   },
-  plugins: [require("tailwindcss-animate"),    require('@tailwindcss/typography'),
-  ],
-  
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 };
 export default config;


### PR DESCRIPTION
Addresses the following feedback:
- [x] Scrolling up should trigger the reverse of the animation 
- [x] Let's slow down the animation when tabs slide out just a tad — maybe 120% of the current length 
- [x] Let's add a *bit* more space to the bottom of each page before the scroll triggers the animation. Right now, especially if I'm scrolling fast, it feels a bit abrupt 
- [x] Check sans font 
- [x] Let's make the overlap consistent on screen sizes

For the first three, I've changed the way the scrolling between pages works to support reverse scrolling. We now no longer using a "scroll trigger" to jump to the next pane. Instead, once the user reaches the bottom or top of a page, there's a certain threshold that they need "scroll past" to trigger the transition. If the reach the bottom or top of the page with "momentum" (i.e. they're scrolling fast), they're more likely to directly run into that threshold. Play around with this and let me know how it feels.

In terms of the sans font - you have two `global.css` files, one of which doesn't seem to be used. I just moved the `font-family` declarations to the one in the `app` folder. 